### PR TITLE
얼굴 인식 못할 때 아바타 이미지로 대체

### DIFF
--- a/src/containers/main/UserVideo.tsx
+++ b/src/containers/main/UserVideo.tsx
@@ -118,8 +118,7 @@ class Avatar {
 function UserVideoComponent2() {
   const avatarName = useRecoilValue(avatarState);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [avatar] = useState<Avatar | null>(new Avatar(avatarName));
-  // const mindarThreeRef = useRef<MindARThree | null>(null);
+  const [avatar] = useState<Avatar>(new Avatar(avatarName));
 
   useEffect(() => {
     const mindarThree = new MindARThree({
@@ -143,12 +142,12 @@ function UserVideoComponent2() {
         /// 앵커에 아바타 추가
         anchor.group.add(avatar!.gltf.scene);
       }
-    
+
       await mindarThree.start();
-    
-      const video = document.querySelector('video');
+
+      const video = document.querySelector("video");
       if (!video) {
-        console.error('비디오 없음!!!');
+        console.error("비디오 없음!!!");
         return;
       }
 
@@ -158,12 +157,22 @@ function UserVideoComponent2() {
 
       scene.background = videoTexture;
 
+      // 얼굴 인식 못할 때 scene 배경
+      const imgTexture = new THREE.TextureLoader().load(
+        `/avatar/${avatarName}.png`,
+      );
+      imgTexture.wrapS = THREE.RepeatWrapping;
+      imgTexture.wrapT = THREE.RepeatWrapping;
+
       // 받은 정보로 프레임마다 아바타 모양 렌더링
       renderer.setAnimationLoop(() => {
         // 가장 최근의 추정치를 가져옴
         const estimate = mindarThree.getLatestEstimate();
         if (estimate && estimate.blendshapes) {
           avatar!.updateBlendshapes(estimate.blendshapes);
+          scene.background = videoTexture;
+        } else {
+          scene.background = imgTexture;
         }
         renderer.render(scene, camera);
       });


### PR DESCRIPTION
# 풀 리퀘스트 확인 사항

- [x] 작업한 파일에 IDE 경고가 남아있는가?
- [x] 이슈의 작업 범위를 넘지 않았는가?
- [x] 버그 픽스, 리팩토링 등 단순 기능 추가가 아닌 경우  "왜" 변경했는지 명시했는가?

# 요약

얼굴 인식 못할 때 아바타 이미지로 대체

## 주요 변경사항

- UserVideo.tsx 내 setAnimationLoop 에서 얼굴 인식 못할 때 아바타 이미지로 대체하도록 수정함.

## 범위 외 커밋

- 
 
# 내용

# 참고 사항
- Closes #
- Sub of #
- reference link1
